### PR TITLE
Create a punchbox_data helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ Finally, include the `punchbox_attributes` hooks in your main `<body>` tag.
   <%= yield %>
 </body>
 ```
+
+You might also include the attributes with `punchbox_data`, which returns a plain ruby `data:` object. Useful for using with templating languages like Erb, Haml and Slim.
+
+```slim
+body *punchbox_data
+  == yield
+```
+
 ## Usage
 
 Punchbox's syntax is very similar to that of Paloma's.  To run JS on a certain page, you call Punchbox like so:

--- a/lib/punchbox/attribute_helper.rb
+++ b/lib/punchbox/attribute_helper.rb
@@ -5,9 +5,9 @@ module AttributeHelper
   end
 
   def punchbox_data
-    {
-      punchbox_controller: controller_path,
-      punchbox_action: action_name
+    'data' => {
+      'punchbox-controller' => controller_path,
+      'punchbox-action' => action_name
     }
   end
 end

--- a/lib/punchbox/attribute_helper.rb
+++ b/lib/punchbox/attribute_helper.rb
@@ -3,4 +3,11 @@ module AttributeHelper
     "data-punchbox-controller=#{controller_path} " \
       "data-punchbox-action=#{action_name}"
   end
+
+  def punchbox_data
+    {
+      punchbox_controller: controller_path,
+      punchbox_action: action_name
+    }
+  end
 end

--- a/lib/punchbox/attribute_helper.rb
+++ b/lib/punchbox/attribute_helper.rb
@@ -5,9 +5,11 @@ module AttributeHelper
   end
 
   def punchbox_data
-    'data' => {
-      'punchbox-controller' => controller_path,
-      'punchbox-action' => action_name
+    {
+      'data' => {
+        'punchbox-controller' => controller_path,
+        'punchbox-action' => action_name
+      }
     }
   end
 end

--- a/lib/punchbox/version.rb
+++ b/lib/punchbox/version.rb
@@ -1,3 +1,3 @@
 module Punchbox
-  VERSION = '1.0.3'.freeze
+  VERSION = '1.0.4'.freeze
 end


### PR DESCRIPTION
Hi!

Sorry for creating a PR prematurely and without explaining the use of the added code.

The reason for a punchbox_data helper to exist is because Haml, Slim users, (and even Erb users that might be generating the `body` element with a Rails helper) will find it very easy to add the attributes with this helper.

In my case, I could do 
![image](https://user-images.githubusercontent.com/5464881/34180951-77c2e0c4-e4de-11e7-98b3-a460b42cb6a4.png) which is very handy. It's Slim by the way.

I know it's not a critical feature but I figured I'd still submit it in case you also find it useful!

Cheers.
